### PR TITLE
fix(lint): allow unexpected cfgs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,8 @@ ariel-os-boards = { path = "build/imports/ariel-os/src/ariel-os-boards" }
 [dev-dependencies]
 embedded-test = { version = "0.6.1", features = ["ariel-os"] }
 {% endif -%}
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(context, values(any()))',
+] }


### PR DESCRIPTION
This commit add an exception for the lint `unexpected_cfgs` in Cargo.toml

This rule does not get triggered with the default code but will be triggered as soon as the user adds a `pins.rs` file.

This is only to avoid confusion until a better solution is found for assigning pins.