### PR TITLE
chore: update Ariel OS version

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1,7 +1,7 @@
 imports:
   - git:
       url: https://github.com/ariel-os/ariel-os
-      tag: v0.3.0-rc.1
+      tag: v0.3.0
     dldir: ariel-os
 
 apps:


### PR DESCRIPTION
This updates the Ariel OS version to use the latest release (`v0.3.0`) instead of the release candidate.