### PR TITLE
docs: add template README.md

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,11 @@
+# About
+
+This repository contains a template for [`Ariel OS`](https://ariel-os.org) applications or libraries.
+
+Please refer to the Ariel OS [getting started documentation][ariel-os-getting-started] for usage instructions.
+
+With the necessary prerequisites installed, this command generates a new application:
+
+    cargo generate --git https://github.com/ariel-os/ariel-os-template --name <new-project-name>
+
+[ariel-os-getting-started]: https://ariel-os.github.io/ariel-os/0.3.0/docs/book/getting-started.html

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,8 +1,9 @@
 [template]
 cargo_generate_version = ">=0.9.0"
+exclude = [".github"]
 
 [conditional.'crate_type == "bin"']
-ignore = [ "src/lib.rs" ]
+ignore = ["src/lib.rs"]
 
 [conditional.'crate_type == "lib"']
-ignore = [ "src/main.rs" ]
+ignore = ["src/main.rs"]


### PR DESCRIPTION
This PR adds a readme that is shown when looking at the template repository.
The file is also ignored by `cargo-generate.toml`.

The `README.md` is stored in `.github/README.md`, so we can possibly later add a (templated) default readme for the generated application. According to [github docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes#about-readmes), the order is `.github/README.md`, then `README.md`, then `docs/README.md`.

