### PR TITLE
fix: s/exclude/ignore template README.md

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,6 +1,6 @@
 [template]
 cargo_generate_version = ">=0.9.0"
-exclude = [".github"]
+ignore = [".github"]
 
 [conditional.'crate_type == "bin"']
 ignore = ["src/lib.rs"]


### PR DESCRIPTION
#12 set the added template README.md to `exclude`, assuming that would not make it part of the generated project. That's wrong, `exclude` just means, `don't apply any templating`. `ignore`ing is the way to go.

Output with this PR:

```
❯ cargo generate --path ariel-os-template/ --name ariel-os-hello --destination /tmp
🔧   Destination: /tmp/ariel-os-hello ...                                      
🔧   project-name: ariel-os-hello ...                                                                                                                          
🔧   Generating template ...                                                   
[1/7]   Done: .cargo/config.toml                                               
[2/7]   Done: .cargo                                                           
[3/7]   Done: .gitignore                                                       
[4/7]   Done: Cargo.toml                                                                                                                                       
[5/7]   Done: laze-project.yml                                                 
[6/7]   Done: src/main.rs                                                      
[7/7]   Done: src                                                              
🔧   Moving generated files into: `/tmp/ariel-os-hello`...                     
🔧   Initializing a fresh Git repository
✨   Done! New project created /tmp/ariel-os-hello
```

... and no .github in the resulting project.

For reference, here's the output of current main:

```
❯ cargo generate --path ariel-os-template/ --name ariel-os-hello --destination /tmp
🔧   Destination: /tmp/ariel-os-hello ...       
🔧   project-name: ariel-os-hello ...                                          
🔧   Generating template ...                                                   
[1/9]   Done: .cargo/config.toml                                               
[2/9]   Done: .cargo                                                           
[3/9]   Skipped: .github/README.md     
[4/9]   Skipped: .github               
[5/9]   Done: .gitignore               
[6/9]   Done: Cargo.toml               
[7/9]   Done: laze-project.yml         
[8/9]   Done: src/main.rs              
[9/9]   Done: src                      
🔧   Moving generated files into: `/tmp/ariel-os-hello`...
🔧   Initializing a fresh Git repository
✨   Done! New project created /tmp/ariel-os-hello
```

... and yes, `.github/README.md` exists in the resulting project.