### PR TITLE
feat: bump Ariel OS to v0.4.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,1 @@
 include = ["../build/imports/ariel-os/ariel-os-cargo.toml"]
-
-[unstable]
-# This is needed so the "include" statement above works.
-config-include = true

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1,7 +1,7 @@
 imports:
   - git:
       url: https://github.com/ariel-os/ariel-os
-      tag: v0.3.0
+      tag: v0.4.0
     dldir: ariel-os
 
 apps:


### PR DESCRIPTION
This updates the template for the newly released version of Ariel OS.

# Testing

Tested using the following:

```sh
cargo generate --git https://github.com/ROMemories/ariel-os-template --branch feat/ariel-os-v0.4.0
```
before running `laze build -b nrf52840dk`.