### PR TITLE
chore: update to Ariel OS v0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ ariel-os = { path = "build/imports/ariel-os/src/ariel-os", features = [] }
 ariel-os-boards = { path = "build/imports/ariel-os/src/ariel-os-boards" }
 {% if crate_type == "lib" %}
 [dev-dependencies]
-embedded-test = { version = "0.6.1", features = ["ariel-os"] }
+embedded-test = { version = "0.7.1", features = ["ariel-os-09"] }
 {% endif -%}
 
 [lints.rust]

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1,7 +1,7 @@
 imports:
   - git:
       url: https://github.com/ariel-os/ariel-os
-      tag: v0.4.0
+      tag: v0.5.0
     dldir: ariel-os
 
 apps:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,10 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::debug::{exit, log::info, ExitCode};
+use ariel_os::{
+    debug::{ExitCode, exit},
+    log::info,
+};
 
 #[ariel_os::task(autostart)]
 async fn main() {


### PR DESCRIPTION
This upgrades to the newer version of Ariel OS.

## Testing 

app: 
```
cargo generate --git https://github.com/nponsard/ariel-os-template -b chore/update-ariel-0-5-0 --name app
cd app 
laze build -b nrf52840dk run
```

lib: 
```
cargo generate --git https://github.com/nponsard/ariel-os-template -b chore/update-ariel-0-5-0 --name lib --lib
cd lib 
laze build -b nrf52840dk test
```
